### PR TITLE
Node Modules are not flat

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -152,7 +152,7 @@ exports.init = function (express, app, opt) {
 
   options = opt || {};
  
-  var swaggerUI = __dirname + '/../node_modules/swagger-ui/dist';
+  var swaggerUI = __dirname + '/../../swagger-ui/dist';
   // Serve up swagger ui static assets
   var swHandler = express.static(swaggerUI);
   setDefaultUrl(opt.basePath+opt.swaggerJSON, swaggerUI);


### PR DESCRIPTION
as of npm 3 the dependency tree is flat in the node_modules folder
